### PR TITLE
fix: fix missing pip bug and add 'python_executable' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,32 +50,36 @@ See the Inputs section below for details on the defaults and optional configurat
 
 **Optional**. The directory to run flake8 in. Defaults to `.`.
 
-#### `flake8_args`
+### `python_executable`
+
+The name or location of the python executable you want to use. Defaults to `python`.
+
+### `flake8_args`
 
 **Optional**. Command-line arguments to the flake8 executable. Defaults to `""`.
 
 Please note that some command-line arguments can be defined with other fields in your configuration.  You may combine the `args` setting with the other settings below, or use `args` to configure flake8 without the other Action settings.
 
-#### `level`
+### `level`
 
 **Optional**. The log level of the reviewdog reporter. Options: `[info, warning, error]`. Defaults to `error`.
 
-#### `reporter`
+### `reporter`
 
 **Optional**. Reporter of reviewdog command `[github-pr-check, github-pr-review, github-check]`. Defaults to `github-pr-check`.
 
-#### `filter_mode`
+### `filter_mode`
 
 **Optional**. Filtering mode for the reviewdog command `[added, diff_context, file, nofilter]`. Defaults to `added`.
 
-#### `fail_on_error`
+### `fail_on_error`
 
 **Optional**. Exit code for reviewdog when errors are found `[true, false]`. Defaults to `false`.
 
-#### `reviewdog_flags`
+### `reviewdog_flags`
 
 **Optional**. Additional reviewdog flags. Defaults to `""`.
 
-#### `tool_name`
+### `tool_name`
 
 **Optional**. Tool name to use for reviewdog reporter. Defaults to `flake8`.

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: "Working directory relative to the root directory."
     required: false
     default: "."
+  python_executable:
+    description: "Python executable."
+    required: false
+    default: "python"
   flake8_args:
     description: "Additional flake8 arguments."
     required: false
@@ -46,6 +50,7 @@ runs:
       shell: bash
       env:
         INPUT_WORKDIR: ${{ inputs.workdir }}
+        INPUT_PYTHON_EXECUTABLE: ${{ inputs.python_executable }}
         INPUT_FLAKE8_ARGS: ${{ inputs.flake8_Args }}
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}
         INPUT_TOOL_NAME: ${{ inputs.tool_name }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,11 +10,16 @@ export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 export REVIEWDOG_VERSION=v0.14.0
 
 echo "[action-flake8] Installing reviewdog..."
-wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /tmp "${REVIEWDOG_VERSION}"
+wget -qO - https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /tmp "${REVIEWDOG_VERSION}"
+
+if [[ "$(which pip)" == "" ]]; then
+  echo "[action-flake8] Installing pip package..."
+  wget -qO - https://bootstrap.pypa.io/get-pip.py | ${INPUT_PYTHON_EXECUTABLE}
+fi
 
 if [[ "$(which flake8)" == "" ]]; then
   echo "[action-flake8] Installing flake8 package..."
-  python -m pip install --upgrade flake8
+  ${INPUT_PYTHON_EXECUTABLE} -m pip install --upgrade flake8
 fi
 echo "[action-flake8] Flake8 version:"
 flake8 --version


### PR DESCRIPTION
This pull request makes sure that pip will be installed when it is not found. It also adds the `python_executable` action argument, allowing users to specify the python executable they want to use. It was created to solve #35.