### PR TITLE
Add `flake8_extensions` input to allow installing flake8 plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ See the Inputs section below for details on the defaults and optional configurat
 
 Please note that some command-line arguments can be defined with other fields in your configuration.  You may combine the `args` setting with the other settings below, or use `args` to configure flake8 without the other Action settings.
 
+#### `flake8_extensions`
+
+**Optional**. Any additional `flake8` extensions to install. Defaults to `""`.
+
+These are simply `pypi` package names as a space-separated list, e.g. `flake8-docstrings flake8-simplify flake8-unused-arguments flake8-quotes`.
+
 #### `level`
 
 **Optional**. The log level of the reviewdog reporter. Options: `[info, warning, error]`. Defaults to `error`.

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: "Additional flake8 arguments."
     required: false
     default: ""
+  flake8_extensions:
+    description: "The `pypi` package names of any flake8 extensions to install."
+    required: false
+    default: ""
   # Reviewdog related inputs
   github_token:
     description: "GITHUB_TOKEN."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,6 +19,11 @@ fi
 echo "[action-flake8] Flake8 version:"
 flake8 --version
 
+if [[ "${INPUT_FLAKE8_EXTENSIONS}" != "" ]]; then
+  echo "[action-flake8] Installing requested flake8 extensions..."
+  python -m pip install --upgrade ${INPUT_FLAKE8_EXTENSIONS}
+fi
+
 echo "[action-flake8] Checking python code with the flake8 linter and reviewdog..."
 exit_val="0"
 flake8 . ${INPUT_FLAKE8_ARGS} 2>&1 | # Removes ansi codes see https://github.com/reviewdog/errorformat/issues/51


### PR DESCRIPTION
`flake8` supports an extension mechanism that can vastly increase its linting and reporting capabilities. These changes allow for workflows to specify a list of pypi packages to install so users can use flake8 extensions with the Reviewdog action.