### PR TITLE
Make the pre-defined 'errorformat' an input variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,4 +82,8 @@ Please note that some command-line arguments can be defined with other fields in
 
 #### `tool_name`
 
-**Optional**. Tool name to use for reviewdog reporter. Defaults to `flake8`.
+**Optional**. Tool name to use for reviewdog reporter. Defaults to `flake8`..
+
+#### `error_format`
+
+**Optional**. Pre-defined error format `[flake8, pep8]`. Defaults to `flake8`.

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: "Tool name to use for reviewdog reporter."
     required: false
     default: "flake8"
+  error_format:
+    description: "Pre-defined error format [flake8, pep8]"
+    required: false
+    default: "flake8"
   level:
     description: "Report level for reviewdog [info, warning, error]."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,7 @@ runs:
         INPUT_FLAKE8_ARGS: ${{ inputs.flake8_Args }}
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}
         INPUT_TOOL_NAME: ${{ inputs.tool_name }}
+        INPUT_ERROR_FORMAT: ${{ inputs.error_format }}
         INPUT_LEVEL: ${{ inputs.level }}
         INPUT_REPORTER: ${{ inputs.reporter }}
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,7 @@ flake8 --version
 echo "[action-flake8] Checking python code with the flake8 linter and reviewdog..."
 exit_val="0"
 flake8 . ${INPUT_FLAKE8_ARGS} 2>&1 | # Removes ansi codes see https://github.com/reviewdog/errorformat/issues/51
-  /tmp/reviewdog -f=flake8 \
+  /tmp/reviewdog -f="${INPUT_ERROR_FORMAT}" \
     -name="${INPUT_TOOL_NAME}" \
     -reporter="${INPUT_REPORTER}" \
     -filter-mode="${INPUT_FILTER_MODE}" \


### PR DESCRIPTION
When creating new, custom linter rules with flake8 and ast, the plugin code has to match this regex: ^[A-Z]{1,3}[0-9]{0,3}$. 

However, the pre-defined 'errorformat' `flake8` does not parse all these plugin codes as expected. But the pre-defined `pep8` does.  

To be able to see warnings for custom linter rules, it would be necessary to make the error format an (optional) input parameter. (https://github.com/reviewdog/action-flake8/issues/48)

This was done here.