### PR TITLE
Add fail_level and deduplicate fail_on_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,15 @@ Please note that some command-line arguments can be defined with other fields in
 
 **Optional**. Filtering mode for the reviewdog command `[added, diff_context, file, nofilter]`. Defaults to `added`.
 
+### `fail_level`
+
+**Optional**. If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+Possible values: [`none`, `any`, `info`, `warning`, `error`]
+Default is `none`.
+
 #### `fail_on_error`
 
+Deprecated, use `fail_level` instead.
 **Optional**. Exit code for reviewdog when errors are found `[true, false]`. Defaults to `false`.
 
 #### `reviewdog_flags`

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Please note that some command-line arguments can be defined with other fields in
 
 ### `fail_level`
 
-**Optional**. If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+**Optional**. If set to `none`, always use exit code 0 for reviewdog.
+Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
 Possible values: [`none`, `any`, `info`, `warning`, `error`]
 Default is `none`.
 

--- a/action.yml
+++ b/action.yml
@@ -35,8 +35,15 @@ inputs:
     description: "Filtering mode for the reviewdog command [added, diff_context, file, nofilter]."
     required: false
     default: "added"
+  fail_level:
+    description: |
+      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      Possible values: [none,any,info,warning,error]
+      Default is `none`.
+    default: 'none'
   fail_on_error:
-    description: "Exit code for reviewdog when errors are found [true, false]."
+    description: "Deprecated, use `fail_level` instead. Exit code for reviewdog when errors are found [true, false]."
+    deprecationMessage: Deprecated, use `fail_level` instead.
     required: false
     default: "false"
   reviewdog_flags:
@@ -57,6 +64,7 @@ runs:
         INPUT_LEVEL: ${{ inputs.level }}
         INPUT_REPORTER: ${{ inputs.reporter }}
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}
+        INPUT_FAIL_LEVEL: ${{ inputs.fail_level }}
         INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
         INPUT_REVIEWDOG_FLAGS: ${{ inputs.reviewdog_flags }}
 

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,8 @@ inputs:
     default: "added"
   fail_level:
     description: |
-      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      If set to `none`, always use exit code 0 for reviewdog.
+      Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
       Possible values: [none,any,info,warning,error]
       Default is `none`.
     default: 'none'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,6 +26,7 @@ flake8 . ${INPUT_FLAKE8_ARGS} 2>&1 | # Removes ansi codes see https://github.com
     -name="${INPUT_TOOL_NAME}" \
     -reporter="${INPUT_REPORTER}" \
     -filter-mode="${INPUT_FILTER_MODE}" \
+    -fail-level="${INPUT_FAIL_LEVEL}" \
     -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
     -level="${INPUT_LEVEL}" \
     ${INPUT_REVIEWDOG_FLAGS} || exit_val="$?"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,6 +21,7 @@ flake8 --version
 
 echo "[action-flake8] Checking python code with the flake8 linter and reviewdog..."
 exit_val="0"
+# shellcheck disable=SC2086
 flake8 . ${INPUT_FLAKE8_ARGS} 2>&1 | # Removes ansi codes see https://github.com/reviewdog/errorformat/issues/51
   /tmp/reviewdog -f="${INPUT_ERROR_FORMAT}" \
     -name="${INPUT_TOOL_NAME}" \


### PR DESCRIPTION
In https://github.com/reviewdog/reviewdog/pull/1854, we add `-fail-level` to reviewdog and deduplicate `-fail-on-error`.
I apply it to this actions.